### PR TITLE
Python3 improvements

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/run
+++ b/run
@@ -78,6 +78,7 @@ db_container="${project}-db"
 db_volume="${project}-db"
 swift_volume="${project}-swift"
 network_name="${project}-net"
+db_network_alias="db"
 
 # Defaults environment settings
 PORT=8000
@@ -149,6 +150,7 @@ django_run () {
         --volume ${pip_cache_volume}:/home/shared/.cache/pip/  `# Bind cache to volume` \
         --env PORT=${PORT}                                     `# Set the port correctly`  \
         --env DJANGO_DEBUG=${DJANGO_DEBUG}                     `# Set django debug mode`  \
+        --env DATABASE_URL=${db_network_alias}                 `# Set django debug mode`  \
         ${extra_options}                                       `# Any extra docker options`  \
         ${django_image} ${command}                             `# Run command in the Django image`
 }
@@ -157,13 +159,13 @@ start_database () {
     container_name="${1}"
     if ! docker inspect -f {{.State.Running}} ${container_name} &>/dev/null; then
         docker run \
-            --name ${container_name}          `# Name the container`  \
-            --rm                              `# Remove the container once it's finished`  \
-            --volume "${db_volume}":/data/db  `# Store dependencies in a docker volume`  \
-            --network "${network_name}"       `# Use an isolated network`  \
-            --network-alias db                `# Call this container "db" on the network so it can be found`  \
-            --detach                          `# Run in the background` \
-            mongo                             `# Use the _library/mongo image`
+            --name ${container_name}             `# Name the container`  \
+            --rm                                 `# Remove the container once it's finished`  \
+            --volume "${db_volume}":/data/db     `# Store dependencies in a docker volume`  \
+            --network "${network_name}"          `# Use an isolated network`  \
+            --network-alias ${db_network_alias}  `# Call this container "db" on the network so it can be found`  \
+            --detach                             `# Run in the background` \
+            mongo                                `# Use the _library/mongo image`
     fi
 }
 

--- a/webapp/auth.py
+++ b/webapp/auth.py
@@ -20,7 +20,7 @@ def token_authorization(target_function):
 
         # Combine request parameters
         params = request.GET.dict()
-        params.update(request.data.dict())
+        params.update(request.data)
 
         # Token based authorization
         if auth_header[:6].lower() == "token ":

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -61,7 +61,7 @@ REST_FRAMEWORK = {
 }
 
 MONGO_DB = mongo_db_from_url(
-    mongo_url=os.environ.get('MONGO_URL', 'db'),
+    mongo_url=os.environ.get('DATABASE_URL', 'localhost'),
     default_database='assets'
 )
 


### PR DESCRIPTION
- Fix a problem with `request.data` when run through WSGI
- Look for database on `localhost` by default in Django settings, only specifying a different location inside the `./run` script itself.
- Use python3 by default in manage.py

QA
--

First set up a local environment:

``` bash
python3 -m venv env3
source env3/bin/activate
pip install -r requirements.txt
pip install gunicorn
```

Check the assets server works more-or-less as expected when run all three different ways:

**./run**

``` bash
./run
```

**through manage.py**

(either verify that it's *looking* for mongo on localhost, and timing out, or install mongo locally to test it can find it)

``` bash
./manage.py runserver
```

**through WSGI**

``` bash
gunicorn webapp.wsgi
```